### PR TITLE
allow passing css modules object to cssModulesPath

### DIFF
--- a/lib/cssModules.es6
+++ b/lib/cssModules.es6
@@ -26,6 +26,15 @@ export default (cssModulesPath) => {
 
 
 function getCssClassName(cssModulesPath, cssModuleName) {
+    if (typeof cssModulesPath === 'string') {
+        return getCssClassNameFromPath(cssModulesPath, cssModuleName);
+    } else {
+        return getCssClassNameFromObject(cssModulesPath, cssModuleName);
+    }
+}
+
+
+function getCssClassNameFromPath(cssModulesPath, cssModuleName) {
     if (fs.lstatSync(cssModulesPath).isDirectory()) {
         let cssModulesDir = cssModulesPath;
         let cssModuleNameParts = cssModuleName.split('.');
@@ -36,6 +45,11 @@ function getCssClassName(cssModulesPath, cssModuleName) {
 
     const cssModules = getCssModules(path.resolve(cssModulesPath));
 
+    return getCssClassNameFromObject(cssModules, cssModuleName);
+}
+
+
+function getCssClassNameFromObject(cssModules, cssModuleName) {
     return cssModuleName.trim().split(' ')
         .map(cssModuleName => {
             const cssClassName = _get(cssModules, cssModuleName);
@@ -43,7 +57,7 @@ function getCssClassName(cssModulesPath, cssModuleName) {
                 throw getError('CSS module "' + cssModuleName + '" is not found');
             } else if (typeof cssClassName !== 'string') {
                 throw getError('CSS module "' + cssModuleName + '" is not a string');
-            }    
+            }
             return cssClassName;
         })
         .join(' ');

--- a/test/cssModules.js
+++ b/test/cssModules.js
@@ -5,6 +5,7 @@ import cssModules from '..';
 
 const classesPath = path.join(__dirname, 'classes.json');
 const classesDir = path.dirname(classesPath);
+const classesObj = require(classesPath);
 
 
 describe('posthtml-css-modules', () => {
@@ -47,6 +48,15 @@ describe('posthtml-css-modules', () => {
             '<div css-module="classes.title"></div>',
             '<div class="__title __heading"></div>',
             classesDir
+        );
+    });
+
+
+    it('should inline CSS module from the object', () => {
+        return init(
+            '<div css-module="title"></div>',
+            '<div class="__title __heading"></div>',
+            classesObj
         );
     });
 


### PR DESCRIPTION
I want to do like below...

```javascript
postcss([
  require('postcss-modules')({
    getJSON: function(cssFileName, json) {
      posthtml([require('posthtml-css-modules')(json)]).process(html).then(...);
    }
  })
]);
```
